### PR TITLE
Fix require to generate parser.rb without edit

### DIFF
--- a/assets/parse.y
+++ b/assets/parse.y
@@ -109,7 +109,7 @@ rule
 end
 
 ---- header
-require './lexer'
+require_relative './lexer'
 
 ---- inner
   #//


### PR DESCRIPTION
Racc source(assets/parse.y) and output(lib/hcl/parser.rb) have different require.
##### assets/parse.y

```
require './lexer'
```
##### lib/hcl/parser.rb

```
require_relative './lexer'
```
