### PR TITLE
Property handle string

### DIFF
--- a/assets/parse.y
+++ b/assets/parse.y
@@ -126,7 +126,7 @@ require './lexer'
       h[a.first] =
         case a.last
         when Hash
-          (h[a.first] || {}).update(a.last)
+          deep_merge(h[a.first] || {}, a.last)
         else
           h[a.first] = a.last
         end
@@ -149,4 +149,19 @@ require './lexer'
 
   def next_token
     @lexer.shift
+  end
+
+  def deep_merge(hash1, hash2)
+    hash2.keys.each do |key|
+      value1 = hash1[key]
+      value2 = hash2[key]
+
+      if value1.is_a?(Hash) && value2.is_a?(Hash)
+        hash1[key] = deep_merge(value1, value2)
+      else
+        hash1[key] = value2
+      end
+    end
+
+    hash1
   end

--- a/lib/hcl/parser.rb
+++ b/lib/hcl/parser.rb
@@ -25,7 +25,7 @@ module_eval(<<'...end parse.y/module_eval...', 'parse.y', 115)
       h[a.first] =
         case a.last
         when Hash
-          (h[a.first] || {}).update(a.last)
+          deep_merge(h[a.first] || {}, a.last)
         else
           h[a.first] = a.last
         end
@@ -48,6 +48,21 @@ module_eval(<<'...end parse.y/module_eval...', 'parse.y', 115)
 
   def next_token
     @lexer.shift
+  end
+
+  def deep_merge(hash1, hash2)
+    hash2.keys.each do |key|
+      value1 = hash1[key]
+      value2 = hash2[key]
+
+      if value1.is_a?(Hash) && value2.is_a?(Hash)
+        hash1[key] = deep_merge(value1, value2)
+      else
+        hash1[key] = value2
+      end
+    end
+
+    hash1
   end
 ...end parse.y/module_eval...
 ##### State transition tables begin ###


### PR DESCRIPTION
When defined multiple strings in same line, these items are handled as single string.
##### sample.tf

```
resource "aws_security_group" "web_security_group" {
  depends_on = [
    "aws_security_group.dummy1", "aws_security_group.dummy2", "aws_security_group.dummy3"
  ]
  name = "WebSecurityGroup"
}
```

```
[4] pry(main)> content = HCLParser.new.parse(File.read('./sample.tf'))
=> {"resource"=>
  {"aws_security_group\" \"web_security_group"=>
    {"depends_on"=>["aws_security_group.dummy1\", \"aws_security_group.dummy2\", \"aws_security_group.dummy3"],
     "name"=>"WebSecurityGroup"}}}
[5] pry(main)> content['resource']['aws_security_group" "web_security_group']['depends_on'].size
=> 1
```
### First commit(https://github.com/sikula/ruby-hcl/commit/f1b87411c4de728fdca739ebd88ebb159d8c8392)

Implements `consume_string` that can handle string with interpolation like https://github.com/hashicorp/hcl/blob/master/hcl/scanner/scanner.go.
### Second commit(https://github.com/sikula/ruby-hcl/commit/db04570ac3919acb34bb0110e3203db44469798e)

Properly flatten object list that has multiple keys like following HCL.

```
resource "aws_security_group" "web_security_group" {
}

resource "aws_security_group" "ap_security_group" {
}
```
