### PR TITLE
Allow - and . in IDENTIFIER

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 
 desc "Generate Lexer"
 task :lexer do
- `rex  ./assets/lexer.rex -o ./lib/lexer.rb`
+ `rex  ./assets/lexer.rex -o ./lib/hcl/lexer.rb`
 end
 
 desc "Generate Parser"

--- a/assets/lexer.rex
+++ b/assets/lexer.rex
@@ -12,7 +12,7 @@ macro
   NUMBER                -?\d+
   FLOAT                 \-?\d+\.\d+
   COMMA                 \,
-  IDENTIFIER            [a-zA-Z_][a-zA-Z0-9_]*
+  IDENTIFIER            [a-zA-Z_][a-zA-Z0-9_\-\.]*
   EQUAL                 \=
   QUOTE                 \"
   MINUS                 \-

--- a/lib/hcl/lexer.rb
+++ b/lib/hcl/lexer.rb
@@ -96,7 +96,7 @@ class HCLLexer
       when (text = @ss.scan(/\,/))
          action { [:COMMA,        text]}
 
-      when (text = @ss.scan(/[a-zA-Z_][a-zA-Z0-9_]*/))
+      when (text = @ss.scan(/[a-zA-Z_][a-zA-Z0-9_\-\.]*/))
          action { [:IDENTIFIER,   text]}
 
       when (text = @ss.scan(/\=/))


### PR DESCRIPTION
'-' and '.' can be in IDENTIFIER so long as they aren't the first character.
